### PR TITLE
Localized display names fix

### DIFF
--- a/twitch_extended/lib/ircparser.lua
+++ b/twitch_extended/lib/ircparser.lua
@@ -137,12 +137,12 @@ websocketMessage = function(data)
 
     message.prefix = data:sub(position + 1, nextspace - 1)
     position = nextspace + 1
-	
-	-- Use Twitch username as fallback when the display name consists entirely of special characters
-	-- E.g. when display name is Japanese, Chinese or Korean
-	if message.tags["display-name"] == '' then
-		message.tags["display-name"] = message.prefix:sub(0, message.prefix:find("!") - 1)
-	end
+    
+    -- Use Twitch username as fallback when the display name consists entirely of special characters
+    -- E.g. when display name is Japanese, Chinese or Korean
+    if message.tags["display-name"] == '' then
+        message.tags["display-name"] = message.prefix:sub(0, message.prefix:find("!") - 1)
+    end
 
     while data:sub(position, position) == ' ' do
         position = position + 1

--- a/twitch_extended/lib/ircparser.lua
+++ b/twitch_extended/lib/ircparser.lua
@@ -137,6 +137,12 @@ websocketMessage = function(data)
 
     message.prefix = data:sub(position + 1, nextspace - 1)
     position = nextspace + 1
+	
+	-- Use Twitch username as fallback when the display name consists entirely of special characters
+	-- E.g. when display name is Japanese, Chinese or Korean
+	if message.tags["display-name"] == '' then
+		message.tags["display-name"] = message.prefix:sub(0, message.prefix:find("!") - 1)
+	end
 
     while data:sub(position, position) == ' ' do
         position = position + 1


### PR DESCRIPTION
Using fallback Twitch username when display name from incoming IRC message is empty.
This will allow users with special display names (like Chinese, Japanese or Korean) to still participate in chat using their Twitch username, and they will also be able to use the voting system.
**Note: Special characters inside messages will still not be displayed**

Small work-around for viewers from Asian countries #8 